### PR TITLE
Respect all the org-agenda-files formats

### DIFF
--- a/nano-agenda.el
+++ b/nano-agenda.el
@@ -339,7 +339,7 @@ for efficiency."
     (if entry
         (cadr entry)
       (progn
-        (dolist (file org-agenda-files)
+        (dolist (file (org-agenda-files))
           (dolist (entry (org-agenda-get-day-entries file date))
             (if (nano-agenda-select-entry entry)
                 (setq level (+ level 1)))))
@@ -373,7 +373,7 @@ for efficiency."
     ;; Body (only timed entries)
 
     ;; Collect all entries with 'time-of-day
-    (dolist (file org-agenda-files)
+    (dolist (file (org-agenda-files))
       (dolist (entry (org-agenda-get-day-entries file date))
         (if (nano-agenda-select-entry entry)
             (add-to-list 'entries entry))))


### PR DESCRIPTION
`org-agenda-files` can be not only a list of files. It can be:
- a list of files (currently supported)
- a path to a directory with the agenda files
- a path to a file with the agenda files listed one per line

The function with the same name handles all these cases.